### PR TITLE
Fix Broken Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
                     <!--Slide 6.1-->
                     <section>
                         <figure>
-                            <img src="https://upload.wikimedia.org/wikipedia/en/0/01/Soybean_Grain_Yield_Map.jpg">
+                            <img src="https://upload.wikimedia.org/wikipedia/commons/0/01/Soybean_Grain_Yield_Map.jpg">
                             <figcaption>Sample precision ag heatmap showing soybean yield</figcaption>
                         </figure>
                     </section>


### PR DESCRIPTION
Looks like Wikipedia changed the link to the precision ag image.